### PR TITLE
do not attempt to bind non-closures

### DIFF
--- a/specs/scope.spec.php
+++ b/specs/scope.spec.php
@@ -27,7 +27,7 @@ describe('Scope', function() {
     });
 
     describe('->peridotBindTo()', function() {
-        it('should bind a callable to the scope', function() {
+        it('should bind a Closure to the scope', function() {
             $callable = function() {
                 return $this->name;
             };
@@ -35,6 +35,15 @@ describe('Scope', function() {
             $bound = $scope->peridotBindTo($callable);
             $result = $bound();
             assert($result == "brian", "scope should have been bound to callable");
+        });
+
+        it('should return non closures', function () {
+            $callable = 'strpos';
+            $scope = new TestScope();
+
+            $bound = $scope->peridotBindTo($callable);
+
+            assert($bound === 'strpos');
         });
     });
 

--- a/src/Scope.php
+++ b/src/Scope.php
@@ -68,7 +68,10 @@ class Scope
      */
     public function peridotBindTo(callable $callable)
     {
-        return Closure::bind($callable, $this, $this);
+        if ($callable instanceof Closure) {
+            return Closure::bind($callable, $this, $this);
+        }
+        return $callable;
     }
 
     /**


### PR DESCRIPTION
`Closure::bind` has no affect on global functions or object methods, and throws a warning.

This PR causes the `peridotBindTo` method to return any callables "as-is" if they are not closures.