### PR TITLE
Callable scope properties.

### DIFF
--- a/specs/scope.spec.php
+++ b/specs/scope.spec.php
@@ -99,7 +99,7 @@ describe('Scope', function() {
         });
     });
 
-    context('when calling a mixed in property', function() {
+    context('when accessing a mixed in property', function() {
         it('should throw an exception when property not found', function() {
             $exception = null;
             try {
@@ -148,6 +148,41 @@ describe('Scope', function() {
                 assert($name === "brian", "expected result of TestScope::name");
                 assert($surname === "scaturro", "expected result of TestChildScope::surname");
             });
+        });
+    });
+
+    context('when calling a property directly on the scope', function() {
+        it('should throw an exception when property not found', function() {
+            $exception = null;
+            try {
+                $this->scope->nope();
+            } catch (\Exception $e) {
+                $exception = $e;
+            }
+            assert(!is_null($exception), 'exception should not be null');
+        });
+
+        it('should throw an exception when property not callable', function() {
+            $this->scope->name = "brian";
+            $exception = null;
+            try {
+                $this->scope->name();
+            } catch (\Exception $e) {
+                $exception = $e;
+            }
+            assert(!is_null($exception), 'exception should not be null');
+        });
+
+        it('should call the property when callable', function() {
+            $this->scope->callback = 'implode';
+            assert($this->scope->callback(['a', 'b']) === "ab", "callable property should be callable");
+        });
+
+        it('should bind the property to the scope before calling', function() {
+            $this->scope->callback = function () {
+                return $this;
+            };
+            assert($this->scope->callback() === $this->scope, "callable property should be bound");
         });
     });
 });

--- a/src/Scope.php
+++ b/src/Scope.php
@@ -82,6 +82,9 @@ class Scope
      */
     public function __call($name, $arguments)
     {
+        if (isset($this->$name) && is_callable($this->$name)) {
+            return call_user_func_array($this->peridotBindTo($this->$name), $arguments);
+        }
         list($result, $found) = $this->peridotScanChildren($this, function ($childScope, &$accumulator) use ($name, $arguments) {
             if (method_exists($childScope, $name)) {
                 $accumulator = [call_user_func_array([$childScope, $name], $arguments), true];


### PR DESCRIPTION
This PR allows for callable properties set on a scope to be directly callable without the need to use `call_user_func()` et al.

Sometimes it is useful to have simple helper functions that exist only for a specific spec. For example, a function to aid in the creation of mock objects:

```php
beforeEach(function () {
    $this->createMock = function ($className) {
        $mock = mock($className); // create mock

        // customize behavior etc.

        return $mock;
    };
});
```

Currently, in order to execute this function from within a test, it is necessary to use `call_user_func()` or similar:

```php
it('calls the createMock() function', function () {
    $mock = call_user_func($this->createMock, 'ClassName');
});
```

This PR allows calling any "callable" property directly:

```php
it('calls the createMock() function', function () {
    $mock = $this->createMock('ClassName');
});
```

Which is something that is already possible in most JavaScript describe/it style test runners, simply because of the nature of JavaScript.